### PR TITLE
Fix: Parameter dependency on acr, documentation

### DIFF
--- a/component/Makefile.vars.mk
+++ b/component/Makefile.vars.mk
@@ -1,11 +1,11 @@
 # Commodore takes the root dir name as the component name
-COMPONENT_NAME ?= $(shell basename $(shell dirname ${PWD}) | sed s/^component-//)
+COMPONENT_NAME ?= cloudscale-metrics-collector
 COMPONENT_SUBDIR ?= $(shell basename ${PWD})
 
 compiled_path   ?= compiled/$(COMPONENT_NAME)/$(COMPONENT_NAME)
 root_volume     ?= -v "$${PWD}/../:/$(COMPONENT_NAME)"
 compiled_volume ?= -v "$${PWD}/$(compiled_path):/$(COMPONENT_NAME)"
-commodore_args  ?= -r ../ --search-paths .
+commodore_args  ?= --search-paths . -n $(COMPONENT_NAME)
 
 ifneq "$(shell which docker 2>/dev/null)" ""
 	DOCKER_CMD    ?= $(shell which docker)

--- a/component/class/defaults.yml
+++ b/component/class/defaults.yml
@@ -1,6 +1,5 @@
 parameters:
   cloudscale_metrics_collector:
-    namespace: 'appuio-cloud-reporting'
     secrets:
       cloudscale:
         stringData:

--- a/component/component/main.jsonnet
+++ b/component/component/main.jsonnet
@@ -1,6 +1,7 @@
 local kap = import 'lib/kapitan.libjsonnet';
 local inv = kap.inventory();
 local params = inv.parameters.cloudscale_metrics_collector;
+local paramsACR = inv.parameters.appuio_cloud_reporting;
 local kube = import 'lib/kube.libjsonnet';
 local com = import 'lib/commodore.libjsonnet';
 local collectorImage = '%(registry)s/%(repository)s:%(tag)s' % params.images.collector;
@@ -16,7 +17,7 @@ local secrets = [
   if params.secrets[s] != null then
     kube.Secret(s) {
       metadata+: {
-        namespace: params.namespace,
+        namespace: paramsACR.namespace,
       }
     } + com.makeMergeable(params.secrets[s])
   for s in std.objectFields(params.secrets)
@@ -34,7 +35,7 @@ local secrets = [
     apiVersion: 'batch/v1',
     metadata: {
       name: 'cloudscale-metrics-collector',
-      namespace: params.namespace,
+      namespace: paramsACR.namespace,
       labels+: labels,
     },
     spec: {
@@ -72,7 +73,7 @@ local secrets = [
                     },
                     {
                       name: 'ACR_DB_URL',
-                      value: 'postgres://$(username):$(password)@reporting-db.appuio-reporting.svc:5432/reporting?sslmode=disable',
+                      value: 'postgres://$(username):$(password)@%(host)s:%(port)s/%(name)s?%(parameters)s' % paramsACR.database,
                     },
                     {
                       name: 'CLOUDSCALE_API_TOKEN',

--- a/component/tests/defaults.yml
+++ b/component/tests/defaults.yml
@@ -1,2 +1,9 @@
-# parameters:
-#  cloudscale_metrics_collector: {}
+parameters:
+  appuio_cloud_reporting:
+    namespace: 'appuio-cloud-reporting'
+    database:
+      name: 'reporting'
+      host: 'reporting-db.appuio-reporting.svc'
+      parameters: 'sslmode=disable'
+      password: 'passw0rd'
+      port: 5432

--- a/docs/modules/ROOT/pages/how-tos/installation.adoc
+++ b/docs/modules/ROOT/pages/how-tos/installation.adoc
@@ -2,7 +2,7 @@
 
 == Requirements
 
-This component requires https://github.com/appuio/component-appuio-cloud-reporting[component-appuio-cloud-reporting] and must be installed into the same namespace.
+This component requires https://github.com/appuio/component-appuio-cloud-reporting[component-appuio-cloud-reporting] and is installed into the same namespace.
 This is required for this component to be able to access the billing database and its connection secrets.
 
 == Example

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -1,23 +1,21 @@
 = Parameters
 
-The parent key for all of the following parameters is `cloudscale_metrics_collector`.
+Because this component depends on the component https://hub.syn.tools/appuio-cloud-reporting/references/parameters.html[appuio-cloud-reporting], some parameters are taken from that component and are not individually configurable in this component.
+In particular:
+
+* https://hub.syn.tools/appuio-cloud-reporting/references/parameters.html#_namespace[namespace]
+* https://hub.syn.tools/appuio-cloud-reporting/references/parameters.html#_database[database]
+
+The following list includes only parameters of this component.
+The parent key for all of them is `cloudscale_metrics_collector`.
 
 See xref:how-tos/installation.adoc[Installation] for a full example.
-
-== `namespace`
-
-[horizontal]
-type:: string
-default:: `appuio-cloud-reporting`
-
-The namespace in which to deploy this component.
-
 
 == `images`
 
 [horizontal]
 type:: dictionary
-default:: https://github.com/appuio/cloudscale-metrics-collector/blob/master/component/class/defaults.yml[See `class/defaults.yml].
+default:: https://github.com/vshn/cloudscale-metrics-collector/blob/master/component/class/defaults.yml[See `class/defaults.yml].
 
 Dictionary containing the container images used by this component.
 


### PR DESCRIPTION
DB and namespace configuration is now taken from ACR (appuio cloud reporting) parameters to avoid incompatible or duplicate configuration.

This is also now clarified in the documentation.